### PR TITLE
Spotify OAuth and Playlists Display

### DIFF
--- a/prototype/app.py
+++ b/prototype/app.py
@@ -125,3 +125,13 @@ def get_playlist():
     # get the playlist
     get = requests.get('https://api.spotify.com/v1/playlists/' + request.args.get('id'), headers=token[1])
     return jsonify({"playlist": get.json(), "success": True})
+
+@app.route('/amILoggedIn', methods=['GET'])
+def amIloggedIn():
+    token = startup.getAccessToken() # get access token
+    
+    # user is logged into Spotify
+    if token:
+        return jsonify({"isLoggedIn": True})
+    
+    return jsonify({"isLoggedIn": False}) # user not logged into Spotify

--- a/prototype/app.py
+++ b/prototype/app.py
@@ -1,4 +1,5 @@
-from flask import Flask, jsonify, request
+import requests
+from flask import Flask, jsonify, request, redirect, session
 from flask_pymongo import PyMongo
 from flask_cors import CORS
 
@@ -54,6 +55,7 @@ def names():
 import spotipy
 from spotipy.oauth2 import SpotifyClientCredentials
 import api_keys
+import startup
 
 # get the artist name from front end, then hit Spotify api and display albums on the front end
 @app.route('/albumsearch', methods=['GET','POST'])
@@ -80,3 +82,25 @@ def getalbumsbyname():
         #print(album_list)
     
     return jsonify({"albums": album_list})
+
+#################
+# Spotify OAuth #
+#################
+
+@app.route('/login')
+def login():
+    response = startup.getUser()
+    return jsonify({"redirect": response})
+
+@app.route('/callback/')
+def callback():
+    startup.getUserToken(request.args['code'])
+    token = startup.getAccessToken()
+
+    return redirect('http://localhost:3000')
+
+@app.route('/playlists', methods=['GET'])
+def get_playlists():
+    token = startup.getAccessToken()
+    get = requests.get('https://api.spotify.com/v1/me/playlists', headers=token[1])
+    return jsonify({"playlists": get.json()})

--- a/prototype/flask_spotify_auth.py
+++ b/prototype/flask_spotify_auth.py
@@ -7,7 +7,7 @@ HEADER = 'application/x-www-form-urlencoded'
 REFRESH_TOKEN = ''
     
 def getAuth(client_id, redirect_uri, scope):
-    data = "{}client_id={}&response_type=code&redirect_uri={}&scope={}".format(SPOTIFY_URL_AUTH, client_id, redirect_uri, scope) 
+    data = "{}client_id={}&response_type=code&redirect_uri={}&scope={}&show_dialog=true".format(SPOTIFY_URL_AUTH, client_id, redirect_uri, scope) 
     return data
 
 def getToken(code, client_id, client_secret, redirect_uri):

--- a/prototype/flask_spotify_auth.py
+++ b/prototype/flask_spotify_auth.py
@@ -1,0 +1,44 @@
+import base64, json, requests
+
+SPOTIFY_URL_AUTH = 'https://accounts.spotify.com/authorize/?'
+SPOTIFY_URL_TOKEN = 'https://accounts.spotify.com/api/token/'
+RESPONSE_TYPE = 'code'   
+HEADER = 'application/x-www-form-urlencoded'
+REFRESH_TOKEN = ''
+    
+def getAuth(client_id, redirect_uri, scope):
+    data = "{}client_id={}&response_type=code&redirect_uri={}&scope={}".format(SPOTIFY_URL_AUTH, client_id, redirect_uri, scope) 
+    return data
+
+def getToken(code, client_id, client_secret, redirect_uri):
+    body = {
+        "grant_type": 'authorization_code',
+        "code" : code,
+        "redirect_uri": redirect_uri,
+        "client_id": client_id,
+        "client_secret": client_secret
+    }
+
+    auth_str = f"{client_id}:{client_secret}"
+    encoded = base64.urlsafe_b64encode(auth_str.encode()).decode()
+    headers = {"Content-Type" : HEADER, "Authorization" : "Basic {}".format(encoded)} 
+
+    post = requests.post(SPOTIFY_URL_TOKEN, params=body, headers=headers)
+    return handleToken(json.loads(post.text))
+    
+def handleToken(response):
+    print(response)
+    auth_head = {"Authorization": "Bearer {}".format(response["access_token"])}
+    REFRESH_TOKEN = response["refresh_token"]
+    return [response["access_token"], auth_head, response["scope"], response["expires_in"]]
+
+def refreshAuth():
+    body = {
+        "grant_type" : "refresh_token",
+        "refresh_token" : REFRESH_TOKEN
+    }
+
+    post_refresh = requests.post(SPOTIFY_URL_TOKEN, data=body, headers=HEADER)
+    p_back = json.dumps(post_refresh.text)
+    
+    return handleToken(p_back)

--- a/prototype/setup.py
+++ b/prototype/setup.py
@@ -1,0 +1,33 @@
+"""
+Flask-Spotify-Auth
+------------------
+Greg VanOrt
+
+This library is used for connecting a flask application to the Spotify OAuth2 interface.
+"""
+
+from setuptools import setup
+
+setup(
+    name='flask-spotify-auth',
+    version='0.1',
+    url='https://github.com/vanortg/flask-spotify-auth',
+    license='MIT',
+    author='Gregory VanOrt',
+    author_email='grvanort@gmail.com',
+    description='Flask library for Spotify user authentication',
+    long_description=__doc__,
+    py_modules=['flask_spotify_auth'],
+    zip_safe=False,
+    include_package_data=True,
+    install_requires=[
+        'Flask',
+    ],
+    classifiers=[
+        'Environment :: Server Environment',
+        'Intended Audience :: Developers',
+        'Operating System :: OS Independent',
+        'License :: OSI Approved :: BSD License',
+        'Programming Language :: Python3',
+    ]
+)

--- a/prototype/src/App.js
+++ b/prototype/src/App.js
@@ -7,6 +7,7 @@ import Home from "./pages/Home";
 import Login from "./pages/Login";
 import Albums from "./pages/Albums";
 import Playlists from "./pages/Playlists";
+import Playlist from "./pages/Playlist";
 
 // instead of accessing our api like this: axios.get('http://localhost:5000/users')
 // this allows us to do this: axios.get('/users')
@@ -22,6 +23,7 @@ const App = () => {
         <Route path="/login" element={<Login />} />
         <Route path="/albums" element={<Albums />} />
         <Route path="/playlists" element={<Playlists/>} />
+        <Route path="/playlist/:id" element={<Playlist/>} />
       </Route>
     </Routes>
   );

--- a/prototype/src/App.js
+++ b/prototype/src/App.js
@@ -5,7 +5,8 @@ import MainLayout from "./components/MainLayout";
 
 import Home from "./pages/Home";
 import Login from "./pages/Login";
-import Albums from "./pages/Albums"
+import Albums from "./pages/Albums";
+import Playlists from "./pages/Playlists";
 
 // instead of accessing our api like this: axios.get('http://localhost:5000/users')
 // this allows us to do this: axios.get('/users')
@@ -20,6 +21,7 @@ const App = () => {
         <Route index element={<Home />} />
         <Route path="/login" element={<Login />} />
         <Route path="/albums" element={<Albums />} />
+        <Route path="/playlists" element={<Playlists/>} />
       </Route>
     </Routes>
   );

--- a/prototype/src/components/Navbar.js
+++ b/prototype/src/components/Navbar.js
@@ -20,6 +20,7 @@ const Navbar = () => {
             CS411 Project
           </Link>
           <Button color="inherit" component={RouterLink} to="/">Home</Button>
+          <Button color="inherit" component={RouterLink} to="/playlists">Playlists</Button>
           <Button color="inherit" component={RouterLink} to="/login">Login</Button>
         </Toolbar>
       </AppBar>

--- a/prototype/src/components/Navbar.js
+++ b/prototype/src/components/Navbar.js
@@ -1,17 +1,25 @@
+import { useEffect, useState } from 'react';
 import {
   AppBar,
   Toolbar,
   Box,
-  IconButton,
   Button,
-  Typography,
   Link
 } from "@mui/material";
 import { Link as RouterLink } from 'react-router-dom';
-
-import MenuIcon from '@mui/icons-material/Menu';
+import axios from 'axios';
 
 const Navbar = () => {
+  const [isLoggedIn, setIsLoggedIn] = useState(false);
+
+  // check if the user is logged in
+  useEffect(() => {
+    axios.get('/amILoggedIn')
+      .then(res => {
+        setIsLoggedIn(res.data.isLoggedIn);
+      })
+  }, []);
+
   return (
   <Box sx={{ flexGrow: 1 }}>
       <AppBar position="static">
@@ -21,7 +29,9 @@ const Navbar = () => {
           </Link>
           <Button color="inherit" component={RouterLink} to="/">Home</Button>
           <Button color="inherit" component={RouterLink} to="/playlists">Playlists</Button>
-          <Button color="inherit" component={RouterLink} to="/login">Login</Button>
+          <Button color="inherit" component={RouterLink} to="/login">
+            {isLoggedIn ? 'Switch Accounts' : 'Login'}
+          </Button>
         </Toolbar>
       </AppBar>
     </Box>

--- a/prototype/src/pages/Login.js
+++ b/prototype/src/pages/Login.js
@@ -1,8 +1,20 @@
 import {
   Box, Typography
 } from '@mui/material';
+import { useEffect } from 'react';
+import axios from 'axios';
 
 const Login = () => {
+  useEffect(() => {
+    axios.get('/login')
+      .then(res => {
+        window.location.href = res.data.redirect;
+      })
+      .catch(err => {
+        console.log(err);
+      });
+  }, [])
+
   return (
     <Box>
       <Typography variant="h3" mb={2}>Login</Typography>

--- a/prototype/src/pages/Login.js
+++ b/prototype/src/pages/Login.js
@@ -1,5 +1,5 @@
 import {
-  Box, Typography
+  Box, Typography, CircularProgress
 } from '@mui/material';
 import { useEffect } from 'react';
 import axios from 'axios';
@@ -17,8 +17,12 @@ const Login = () => {
 
   return (
     <Box>
-      <Typography variant="h3" mb={2}>Login</Typography>
-      <Typography>Example Login Page</Typography>
+      <Typography variant="body1" mb={2}>
+        Redirecting to Spotify Auth...
+      </Typography>
+      <Box>
+        <CircularProgress />
+      </Box>
     </Box>
   )
 }

--- a/prototype/src/pages/Playlist.js
+++ b/prototype/src/pages/Playlist.js
@@ -1,0 +1,68 @@
+import { useEffect, useState } from 'react';
+import { useParams } from 'react-router-dom';
+import {
+  Box, Typography, Grid, Card, CardContent, Stack, CircularProgress
+} from '@mui/material';
+import axios from 'axios';
+
+const Playlist = () => {
+  const { id } = useParams();
+
+  const [playlist, setPlaylist] = useState();
+
+  useEffect(() => {
+    axios.get(`/playlist?id=${id}`)
+      .then(res => {
+        setPlaylist(res.data.playlist)
+      });
+  }, [])
+
+  return (
+    <Box>
+      {playlist && (
+      <Grid container spacing={3}>
+        <Grid item xs={12} md={6} lg={4}>
+          <Card>
+          <img src={playlist?.images[0].url} alt={playlist?.name} width="100%"/>
+          <CardContent>
+            <Typography variant="h5">{playlist?.name}</Typography>
+            <Typography variant="subtitle2">by {playlist?.owner.display_name}</Typography>
+          </CardContent>
+          </Card>
+        </Grid>
+        <Grid item xs={12} md={6} lg={8}>
+          <Typography variant="h4" mb={2}>Tracks</Typography>
+          <Stack spacing={3}>
+            {playlist?.tracks.items.map(track => {
+              return (
+                <Card>
+                  <CardContent>
+                    <Stack direction="row" spacing={2}>
+                    <img src={track.track.album.images[0].url} alt={track.track.name} height={128}/>
+                      <Box>
+                      <Typography variant="h6">{track.track.name}</Typography>
+                      <Typography variant="subtitle2">
+                        {track.track.artists.map(artist => artist.name).join(', ')}
+                      </Typography>
+                      </Box>
+                    </Stack>
+                  </CardContent>
+                </Card>
+              )
+            })}
+          </Stack>
+        </Grid>
+      </Grid>
+      )}
+      {
+        !playlist && (
+          <Box mt={2}>
+            <CircularProgress/>
+          </Box>
+        )
+      }
+    </Box>
+  )
+}
+
+export default Playlist;

--- a/prototype/src/pages/Playlists.js
+++ b/prototype/src/pages/Playlists.js
@@ -1,0 +1,29 @@
+import { useEffect, useState } from 'react';
+import {
+  Box, Typography, TextField, Button, Stack
+} from '@mui/material';
+import axios from 'axios';
+
+const Playlists = () => {
+  const [playlists, setPlaylists] = useState([]);
+
+  useEffect(() => {
+    axios.get('/playlists')
+      .then(res => {
+        setPlaylists(res.data.playlists.items)
+      });
+  }, [])
+
+  return (
+    <Box>
+      <Typography variant="h3" mb={2}>Playlists</Typography>
+      <ul>
+        {playlists?.map(playlist => (
+          <li>Playlist Name: {playlist.name}</li>
+        ))}
+      </ul>
+    </Box>
+  )
+}
+
+export default Playlists;

--- a/prototype/src/pages/Playlists.js
+++ b/prototype/src/pages/Playlists.js
@@ -1,27 +1,50 @@
 import { useEffect, useState } from 'react';
+import { Link as RouterLink } from 'react-router-dom';
 import {
-  Box, Typography, TextField, Button, Stack
+  Box, Typography, Grid, Card, CardContent, Button, CircularProgress
 } from '@mui/material';
 import axios from 'axios';
 
 const Playlists = () => {
   const [playlists, setPlaylists] = useState([]);
+  const [success, setSuccess] = useState(true);
 
   useEffect(() => {
     axios.get('/playlists')
       .then(res => {
         setPlaylists(res.data.playlists.items)
+        setSuccess(res.data.success)
       });
   }, [])
 
   return (
     <Box>
       <Typography variant="h3" mb={2}>Playlists</Typography>
-      <ul>
+      <Grid container spacing={3}>
         {playlists?.map(playlist => (
-          <li>Playlist Name: {playlist.name}</li>
+          <Grid item xs={12} md={6} lg={4}>
+            <Card>
+              <img src={playlist.images[0].url} alt={playlist.name} width="100%"/>
+              <CardContent>
+                <Typography variant="h5">{playlist.name}</Typography>
+                <Typography variant="subtitle2" mb={2}>by {playlist.owner.display_name}</Typography>
+                <Button component={RouterLink} variant="contained" to={`/playlist/${playlist.id}`}>View</Button>
+              </CardContent>
+            </Card>
+          </Grid>
         ))}
-      </ul>
+      </Grid>
+      {!success && (
+        <Typography variant="body1" mt={2}>
+          Please login to view your playlists.
+        </Typography>
+      )}
+      {
+        playlists?.length === 0 && (
+          <Box mt={2}>
+            <CircularProgress/>
+          </Box>
+      )}
     </Box>
   )
 }

--- a/prototype/startup.py
+++ b/prototype/startup.py
@@ -1,0 +1,32 @@
+from flask_spotify_auth import getAuth, refreshAuth, getToken
+import api_keys
+
+#Add your client ID
+CLIENT_ID = api_keys.spotify_id
+
+#aDD YOUR CLIENT SECRET FROM SPOTIFY
+CLIENT_SECRET = api_keys.spotify_secret
+
+#Port and callback url can be changed or ledt to localhost:5000
+PORT = "5000"
+CALLBACK_URL = "http://localhost"
+
+#Add needed scope from spotify user
+SCOPE = "playlist-read-private playlist-read-collaborative"
+#token_data will hold authentication header with access code, the allowed scopes, and the refresh countdown 
+TOKEN_DATA = []
+
+
+def getUser():
+    return getAuth(CLIENT_ID, "{}:{}/callback/".format(CALLBACK_URL, PORT), SCOPE)
+
+def getUserToken(code):
+    global TOKEN_DATA
+    TOKEN_DATA = getToken(code, CLIENT_ID, CLIENT_SECRET, "{}:{}/callback/".format(CALLBACK_URL, PORT))
+ 
+def refreshToken(time):
+    time.sleep(time)
+    TOKEN_DATA = refreshAuth()
+
+def getAccessToken():
+    return TOKEN_DATA


### PR DESCRIPTION
https://user-images.githubusercontent.com/15660380/164304139-09a6702d-54f7-4881-9e97-95083bb91a4b.mov

Users can now view their Playlists and then view an individual playlist to reveal all the tracks in the playlist. Restarting the backend will reset the user’s OAuth status, so you can test signing in again if you restart the backend.